### PR TITLE
Add User Bot Example Using WebSocket/Faye

### DIFF
--- a/Example Bots/UserBotWithWebSocket.js
+++ b/Example Bots/UserBotWithWebSocket.js
@@ -1,0 +1,98 @@
+import WebSocket from 'ws';
+import EventEmitter from 'events';
+import fetch from 'node-fetch';
+
+const group_id = '85327648'
+
+let request_id = 1;
+let client_id;
+const user_id = '38301276';
+const access_token = 'G0uhuY3FaB74igrr12sTxnzrdbsFBu3iWaMpcP5y'
+
+const ws = new WebSocket('wss://push.groupme.com/faye');
+const channels = new EventEmitter()
+
+ws.on('open', () => {
+    handshake();
+});
+
+ws.on('message', data => handle(data));
+
+channels.once('/meta/handshake', (data) => {
+    client_id = data.clientId;
+    subscribe(`/user/${user_id}`);
+})
+
+channels.once('/meta/subscribe', () => {
+    connect();
+})
+
+channels.on('/meta/connect', () => {
+    connect();
+})
+
+channels.on(`/user/${user_id}`, (data) => {
+    const message = data['data']['subject']['text'];
+    if (message.toLowerCase() === '!ping') {
+        send_message(`Pong!`);
+    }
+})
+
+const handle = (data) => {
+    const parsed = JSON.parse(data.toString())[0];
+    channels.emit(parsed.channel, parsed);
+}
+
+const handshake = () => {
+    send({
+        channel: '/meta/handshake',
+        version: '1.0',
+        supportedConnectionTypes: ['websocket'],
+    });
+};
+
+const subscribe = (channel) => {
+    send({
+        channel: '/meta/subscribe',
+        subscription: channel,
+        ext: {access_token: access_token},
+    })
+};
+
+const connect = () => {
+    send({
+        channel: '/meta/connect',
+        connectionType: 'websocket',
+    })
+};
+
+const send = (data) => {
+    data.id = request_id++;
+    data.clientId = client_id;
+    const str = JSON.stringify([data]);
+
+    ws.send(str, err => {
+        if (err) {
+            console.error('An error occurred while trying to send:', data);
+            throw err;
+        }
+    })
+}
+
+const send_message = (message) => {
+    const headers = {'Content-Type': 'application/json'}
+    const body = JSON.stringify(
+        {
+            message: {
+                source_guid: Date.now(),
+                text: message
+            }
+        });
+    fetch(`https://api.groupme.com/v3/groups/${group_id}/messages?token=${access_token}`, {
+        method: 'POST',
+        headers: headers,
+        body: body
+    }).catch(err => {
+        console.error('An error occurred while trying to send:', err);
+    })
+}

--- a/Example Bots/UserBotWithWebSocket.js
+++ b/Example Bots/UserBotWithWebSocket.js
@@ -21,27 +21,27 @@ ws.on('message', data => handle(data));
 channels.once('/meta/handshake', (data) => {
     client_id = data.clientId;
     subscribe(`/user/${user_id}`);
-})
+});
 
 channels.once('/meta/subscribe', () => {
     connect();
-})
+});
 
 channels.on('/meta/connect', () => {
     connect();
-})
+});
 
 channels.on(`/user/${user_id}`, (data) => {
     const message = data['data']['subject']['text'];
     if (message.toLowerCase() === '!ping') {
         send_message(`Pong!`);
     }
-})
+});
 
 const handle = (data) => {
     const parsed = JSON.parse(data.toString())[0];
     channels.emit(parsed.channel, parsed);
-}
+};
 
 const handshake = () => {
     send({
@@ -56,14 +56,14 @@ const subscribe = (channel) => {
         channel: '/meta/subscribe',
         subscription: channel,
         ext: {access_token: access_token},
-    })
+    });
 };
 
 const connect = () => {
     send({
         channel: '/meta/connect',
         connectionType: 'websocket',
-    })
+    });
 };
 
 const send = (data) => {
@@ -76,7 +76,7 @@ const send = (data) => {
             console.error('An error occurred while trying to send:', data);
             throw err;
         }
-    })
+    });
 }
 
 const send_message = (message) => {

--- a/push.md
+++ b/push.md
@@ -1,11 +1,24 @@
 # Push Service
 
-The GroupMe Push Service is strange and finnicky, so giving precise documentation about it is hard. The [official documentation](https://dev.groupme.com/tutorials/push) has a lot of outdated and incomplete information, and it's hard (for me, at least) to figure out what's required and what's not.
+The GroupMe Push Service is strange and finnicky, so giving precise documentation about it is hard.
+The [official documentation](https://dev.groupme.com/tutorials/push) has a lot of outdated and incomplete information,
+and it's hard (for me, at least) to figure out what's required and what's not.
 
-Hopefully someone can figure out how it works and add some details here, but until then, here are some working implementations:
+Hopefully someone can figure out how it works and add some details here, but until then, here are some working
+implementations:
 
-* [My bot, Lowes.](https://github.com/2CATteam/gmuserbot/blob/master/bot.js) I'm sure I stole this working code from somewhere, but I can't for the life of me figure out where.
+* [My bot, Lowes.](https://github.com/2CATteam/gmuserbot/blob/master/bot.js) I'm sure I stole this working code from
+  somewhere, but I can't for the life of me figure out where.
 
 * [The GroupMe npm package](https://github.com/njoubert/node-groupme/blob/master/lib/IncomingStream.js)
 
-Please help improve this page with more examples or, hopefully, some better information on how it works to begin with, and potentially a guide on how to use it.
+Here is a list of some known WebSocket types and what they correspond to:
+
+* `ping` -> A ping from the web socket server
+* `line.create` -> New Group Message
+* `like.create` -> Someone likes a message that is not yours in a group
+* `favorite` -> Someone likes a message that is yours in a group
+* `direct_message.create` -> New Direct Message
+
+Please help improve this page with more examples or, hopefully, some better information on how it works to begin with,
+and potentially a guide on how to use it.


### PR DESCRIPTION
This would add a new bot example for using WebSockets to create a GroupMe bot as well as sending messages as a user as opposed to a bot. It would also add some known WebSocket types to the push.md file.