### PR TITLE
Remove breaking change notice for group creation

### DIFF
--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -291,12 +291,6 @@ Status: 200 OK
 
 Create a new group.
 
-!!! warning "Breaking Change: Device Verification"
-
-    This endpoint now requires platform-level device verification (e.g., Apple App Attest or Google Play Integrity). Requests must include valid attestation headers (`X-verify-token`), or they will be rejected.
-
-    This change was introduced by GroupMe to mitigate automated abuse. Unfortunately, it also blocks all third-party clients, including many valuable community projects. As such, this endpoint is no longer accessible to third-party applications and is retained here for historical reference only.
-
 ```json linenums="1" title="HTTP Request"
 POST /groups
 {


### PR DESCRIPTION
Removed warning about breaking change for device verification requirement on group creation endpoint. I tested and it works perfectly.