### PR TITLE
Small Improvements

### DIFF
--- a/docs/api/account/contacts.md
+++ b/docs/api/account/contacts.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's user relationship system via 
 
 # Users and Contacts
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/account/index.md
+++ b/docs/api/account/index.md
@@ -30,7 +30,7 @@ If the request succeeds, `meta.errors` will be null, and if the request fails, `
 ***
 
 > [!note]
-> Calls related to account security, such as managing your password or updating MFA settings are located in the [Oauth / MFA Management](oauth.md) section.
+> Calls related to account security, such as managing your password or updating MFA settings are located in the [OAuth / MFA Management](oauth.md) section.
 
 ## About
 <!-- official-doc: https://dev.groupme.com/docs/v3#users_me -->

--- a/docs/api/account/index.md
+++ b/docs/api/account/index.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's account profiles via the API.
 
 # Profile Information
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/account/index.md
+++ b/docs/api/account/index.md
@@ -30,7 +30,7 @@ If the request succeeds, `meta.errors` will be null, and if the request fails, `
 ***
 
 > [!note]
-> Calls related to account security, such as managing your password or updating MFA settings are located in the [Oauth / MFA Managment](oauth.md) section.
+> Calls related to account security, such as managing your password or updating MFA settings are located in the [Oauth / MFA Management](oauth.md) section.
 
 ## About
 <!-- official-doc: https://dev.groupme.com/docs/v3#users_me -->
@@ -45,7 +45,7 @@ GET /users/me
 Status: 200 OK
 {
   "created_at": 1622678742,
-  "email": "email@example.con",
+  "email": "email@example.com",
   "email_verified": false,
   "facebook_connected": false,
   "id": "93645911",
@@ -216,7 +216,7 @@ POST https://v2.groupme.com/users/:your_user_id
 
 * *dm_notification sound*
 
-	string — the name of the WAV file to play when you receive a DM notification on the Mobile App. These file names are internal to the app, so the options are not well documented. (However they appear to be the same options as the ones availibe for the `group_notification_sound` parameter).
+	string — the name of the WAV file to play when you receive a DM notification on the Mobile App. These file names are internal to the app, so the options are not well documented. (However they appear to be the same options as the ones available for the `group_notification_sound` parameter).
 
 ```json linenums="1" title="HTTP Response"
 Status: 200 OK
@@ -272,7 +272,7 @@ Status: 200 OK
 
 ## Update Major Tags
 
-This call is only allowed for accounts that are members of a school domain, which is not an easy proccess to automate and thus will not be fully documented. HOWEVER, once you are in a domain, you have a few additional calls availible for your account.
+This call is only allowed for accounts that are members of a school domain, which is not an easy process to automate and thus will not be fully documented. HOWEVER, once you are in a domain, you have a few additional calls available for your account.
 
 ```json linenums="1" title="HTTP Request"
 PUT /directories/user/majors
@@ -302,7 +302,7 @@ Status: 201 Accepted
 
 ## Set Graduation Year and Domain Visibility
 
-This call is only allowed for accounts that are members of a school domain, which is not an easy proccess to automate and thus will not be fully documented. HOWEVER, once you are in a domain, you have a few additional calls availible for your account.
+This call is only allowed for accounts that are members of a school domain, which is not an easy process to automate and thus will not be fully documented. HOWEVER, once you are in a domain, you have a few additional calls available for your account.
 
 This call specifies your graduation year tag inside of your profile as well as what level of visibility you want your profile to be at within the campus domain.
 

--- a/docs/api/account/oauth.md
+++ b/docs/api/account/oauth.md
@@ -5,7 +5,7 @@ description: "Learn to manage GroupMe API tokens programmatically"
 
 # Oauth / MFA Management
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/account/oauth.md
+++ b/docs/api/account/oauth.md
@@ -289,7 +289,7 @@ You make this call once without an MFA verification object, receive an MFA ID fo
 After establishing the MFA channel you must enable it with a seperate call.
 
 > [!important]
-> Activating MFA will log you out *everywhere*, including 3rd party Oauth apps. This proccess will invalidate your current API token and return a new one that you should use to make subsequent API calls.
+> Activating MFA will log you out *everywhere*, including 3rd party Oauth apps. This process will invalidate your current API token and return a new one that you should use to make subsequent API calls.
 
 ```json linenums="1" title="HTTP Request"
 POST /user/mfa

--- a/docs/api/account/oauth.md
+++ b/docs/api/account/oauth.md
@@ -1,9 +1,9 @@
 ---
-title: "Oauth / MFA Management"
+title: "OAuth / MFA Management"
 description: "Learn to manage GroupMe API tokens programmatically"
 ---
 
-# Oauth / MFA Management
+# OAuth / MFA Management
 
 Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
@@ -289,7 +289,7 @@ You make this call once without an MFA verification object, receive an MFA ID fo
 After establishing the MFA channel you must enable it with a seperate call.
 
 > [!important]
-> Activating MFA will log you out *everywhere*, including 3rd party Oauth apps. This process will invalidate your current API token and return a new one that you should use to make subsequent API calls.
+> Activating MFA will log you out *everywhere*, including 3rd party OAuth apps. This process will invalidate your current API token and return a new one that you should use to make subsequent API calls.
 
 ```json linenums="1" title="HTTP Request"
 POST /user/mfa
@@ -427,7 +427,7 @@ Status: 200 OK
 
 ***
 
-## Revoking an API token / Oauth Application
+## Revoking an API token / OAuth Application
 
 This call invalidates a token with a particular token ID, which can be identified using the call above.
 

--- a/docs/api/bots/index.md
+++ b/docs/api/bots/index.md
@@ -83,7 +83,7 @@ POST /bots
 		
 	* *avatar_url*
 	
-		string - a URL to an image which will be the bot's avatar. This image MUST be proccessed by GroupMe's [Image Service](../uploads/images.md) before it can be sent.
+		string - a URL to an image which will be the bot's avatar. This image MUST be processed by GroupMe's [Image Service](../uploads/images.md) before it can be sent.
 		
 	* *callback_url*
 	

--- a/docs/api/bots/index.md
+++ b/docs/api/bots/index.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe webhooks via the API."
 
 # Webhook Bots
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/conversations/calendar.md
+++ b/docs/api/conversations/calendar.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's Calandar Events via the API."
 
 # Calendar Events
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/conversations/gallery.md
+++ b/docs/api/conversations/gallery.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's channel-specific image galler
 
 # Image Gallery
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/conversations/pins.md
+++ b/docs/api/conversations/pins.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's pins system via the API."
 
 # Pins
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/conversations/reactions.md
+++ b/docs/api/conversations/reactions.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's reaction system via the API."
 
 # Reactions
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/dms/index.md
+++ b/docs/api/dms/index.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's direct message channels via t
 
 # Direct Messages
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/groups/directories.md
+++ b/docs/api/groups/directories.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's group directories via the API
 
 # Public Directories and Group Discovery
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe group channels via the API."
 
 # Groups
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -27,6 +27,15 @@ Finally, all responses are wrapped in a response envelope of the following form:
 
 If the request succeeds, `meta.errors` will be null, and if the request fails, `response` will be null.
 
+---
+
+!!! important
+
+    Subgroups/subtopics are also groups and can be treated as their own group. If `:group_id` is mentioned in these docs for an endpoint, the endpoint can most likely also apply to a subgroup. For example, retreiving messages, events, etc.
+
+---
+
+
 ***
 
 ## Index

--- a/docs/api/groups/members.md
+++ b/docs/api/groups/members.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's member objects via the API."
 
 # Members
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/groups/messages.md
+++ b/docs/api/groups/messages.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's group message objects via the
 
 # Group Messages
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/groups/polls.md
+++ b/docs/api/groups/polls.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's polling system via the API."
 
 # Polls
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/api/groups/subgroups.md
+++ b/docs/api/groups/subgroups.md
@@ -5,7 +5,7 @@ description: "Learn how to interact with GroupMe's subtopic system via the API."
 
 # Subtopics
 
-Unless otherwise stated, endpoints are relative to https://api.groupme.com/v3/ and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
+Unless otherwise stated, endpoints are relative to `https://api.groupme.com/v3/` and must include the token of the user making the call - so, for example, if an endpoint is `GET /groups`, the request you make should be using the URL `https://api.groupme.com/v3/groups?token=aSDFghJkl`, where `aSDFghJkl` is replaced with the user's token.
 
 URLs which include a variable, such as `GET /groups/:id`, have their variables marked with a colon. So a request to that endpoint would look like `https://api.groupme.com/v3/groups/1234567?token=aSDFghJkl`, where `1234567` is replaced with the group's ID, and `aSDFghJkl` is replaced with the user's token.
 

--- a/docs/contributing/styleguide.md
+++ b/docs/contributing/styleguide.md
@@ -55,7 +55,7 @@ URLs which include a variable, such as `GET /groups/:id`, have their variables m
 
 Finally, all responses are wrapped in a response envelope of the following form:
 
-`"``json linenums="1"
+````json linenums="1"
 {
   "response": {
     "id": "12345",
@@ -67,7 +67,7 @@ Finally, all responses are wrapped in a response envelope of the following form:
     "errors": []
   }
 }
-`"``
+````
 
 If the request succeeds, `meta.errors` will be null, and if the request fails, `response` will be null.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,7 @@ nav:
     - Account Management: 
       - api/account/index.md
       - Contacts: api/account/contacts.md
-      - Oauth/MFA: api/account/oauth.md
+      - OAuth/MFA: api/account/oauth.md
     - Groups:
       - api/groups/index.md
       - Subgroups: api/groups/subgroups.md

--- a/readme.md
+++ b/readme.md
@@ -44,10 +44,10 @@ Here you will find:
 
 This project thrives on community contributions! Whether you're fixing a typo, documenting a newly discovered feature, or improving an example, your help is welcome.
 
-To get started, please read our **[Contributing Guide](https://groupme-js.github.io/GroupMeCommunityDocs/api/contributing)**, which covers:
+To get started, please read our **[Contributing Guide](https://groupme-js.github.io/GroupMeCommunityDocs/contributing/)**, which covers:
 
 -   How to submit changes and open a pull request.
--   The **[Style Guide](https://groupme-js.github.io/GroupMeCommunityDocs/api/contributing/styleguide)** for keeping the docs consistent.
+-   The **[Style Guide](https://groupme-js.github.io/GroupMeCommunityDocs/contributing/styleguide/)** for keeping the docs consistent.
 
 ## Community
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
         <img src="./.github/assets/opengm_logo_colorized.svg" alt="OpenGM Logo" />
         </a>
     </h1>
-  <h2 align="center">GroupMe Community API Docs</h1>
+  <h2 align="center">GroupMe Community API Docs</h2>
   <p align="center">
     The complete, up-to-date, and community-driven documentation for the GroupMe API.
   </p>
@@ -59,7 +59,7 @@ Have a question, an idea, or just want to chat with other GroupMe developers?
 
 This project is under a dual-license model:
 
--   All documentation content is licensed under **[CC-BY-4.0](./docs/LICENSE.md)**.
--   All source code, including examples and snippets, is licensed under the **[MIT License](./docs/LICENSE-CODE.md)**.
+-   All documentation content is licensed under **[CC-BY-4.0](./LICENSE.md)**.
+-   All source code, including examples and snippets, is licensed under the **[MIT License](./LICENSE-CODE.md)**.
 
 By contributing, you agree to license your contributions under these terms.


### PR DESCRIPTION
This change includes the following changes:
- An important note regarding subgroups/subtopics. 
  - I think this is good to have because I didn't know subgroups were basically groups. I thought it wouldn't be possible for me to get events from a subgroup until I just tried on a whim to use the group endpoints for subgroups/topics.
- An updated README.md for accurate linking
- Typo and capitalization corrections for clarity


Also, I've noticed that topics are called subtopics in some places and subgroups in others. What would be the correct language? I know in terms of endpoint paths `subgroups` might be more correct. But I also see `topic` as a returned field in `GET /groups/:group_id/subgroups/:subgroup_id`.