### PR TITLE
docs: document GET /groups/:id full schema, list vs detail delta, and subgroup field additions

### DIFF
--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -220,67 +220,72 @@ Status: 200 OK
 ## Show
 <!-- official-doc: https://dev.groupme.com/docs/v3#groups_show -->
 
-Load a specific group.
+Load a specific group. Returns full detail for a single group.
 
 ```json linenums="1" title="HTTP Request"
-GET /groups/:group_id
+GET /groups/:id
 ```
 
 **Parameters**
 
-* *group_id* (required)
+* *id* (required)
 
 	string - the ID of the group to show details of
+
+**Response Schema**
+
+The detail view contains the complete group schema. Fields marked as **(detail only)** are either not present or less detailed in the [Index](#index) (list) endpoint:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Group ID |
+| `name` | string | Display name |
+| `type` | string | Group visibility: `"private"` or `"closed"` |
+| `description` | string \| null | Optional group description |
+| `image_url` | string \| null | Group avatar image URL |
+| `creator_user_id` | string | ID of the user who created the group |
+| `created_at` | integer | Unix timestamp of group creation |
+| `updated_at` | integer | Unix timestamp of last update |
+| `share_url` | string \| null | Join URL for shared groups |
+| `members` | array | **(detail only)** List of member objects with full details. Each member includes: `id`, `user_id`, `nickname`, `muted`, `image_url` |
+| `messages` | object | **(detail only)** Message metadata including: `count`, `last_message_id`, `last_message_created_at` |
+
+**List vs Detail Differences**
+
+| Aspect | `GET /groups` (List) | `GET /groups/:id` (Detail) |
+|--------|----------------------|---------------------------|
+| Response type | Array of groups | Single group object |
+| Pagination | Yes (`page`, `per_page`) | No |
+| `members` field | May be omitted via `omit=memberships`; when present, member objects exclude `id` | Always present; member objects include `id` field |
+| `messages.preview` | Present | **Not present** in detail view |
+| Complete member data | Limited | Full (includes membership `id`) |
+| Message metadata | Basic + preview | Full stats only (no preview) |
 
 ```json linenums="1" title="HTTP Response"
 Status: 200 OK
 {
-  "id": "1234567890",
-  "name": "Family",
-  "type": "private",
-  "description": "Coolest Family Ever",
-  "image_url": "https://i.groupme.com/123456789",
-  "creator_user_id": "1234567890",
-  "created_at": 1302623328,
-  "updated_at": 1302623328,
+  "id": "100675764",
+  "name": "ISBA Prophets",
+  "type": "closed",
+  "description": "",
+  "image_url": "https://i.groupme.com/500x500.jpeg.3e6a51af2d104dba882cf36014fca0bb",
+  "creator_user_id": "125343076",
+  "created_at": 1714764021,
+  "updated_at": 1773923144,
+  "share_url": "https://groupme.com/join_group/100675764/6aYuFUwY",
   "members": [
     {
-      "user_id": "1234567890",
-      "nickname": "Jane",
+      "id": "971574566",
+      "user_id": "107044098",
+      "nickname": "Khristian Diaz NW",
       "muted": false,
-      "image_url": "https://i.groupme.com/123456789"
+      "image_url": "https://i.groupme.com/1024x1024.jpeg.deca0b2163f14b4f8691b194d4c68918"
     }
   ],
-  "share_url": "https://groupme.com/join_group/1234567890/SHARE_TOKEN",
   "messages": {
-    "count": 100,
-    "last_message_id": "1234567890",
-    "last_message_created_at": 1302623328,
-    "preview": {
-      "nickname": "Jane",
-      "text": "Hello world",
-      "image_url": "https://i.groupme.com/123456789",
-      "attachments": [
-        {
-          "type": "image",
-          "url": "https://i.groupme.com/123456789"
-        },
-        {
-          "type": "location",
-          "lat": "40.738206",
-          "lng": "-73.993285",
-          "name": "GroupMe HQ"
-        },
-        {
-          "type": "emoji",
-          "placeholder": "",
-          "charmap": [
-            [1, 42],
-            [2, 34]
-          ]
-        }
-      ]
-    }
+    "count": 6677,
+    "last_message_id": "177392314469396469",
+    "last_message_created_at": 1773923144
   }
 }
 ```

--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -264,27 +264,27 @@ The detail view contains the complete group schema. Fields marked as **(detail o
 ```json linenums="1" title="HTTP Response"
 Status: 200 OK
 {
-  "id": "GROUP_ID",
-  "name": "GROUP_NAME",
+  "id": "1234567890",
+  "name": "Family",
   "type": "private",
-  "description": "GROUP_DESCRIPTION",
-  "image_url": "https://example.com/avatar.jpeg",
-  "creator_user_id": "USER_ID",
+  "description": "Coolest Family Ever",
+  "image_url": "https://i.groupme.com/123456789",
+  "creator_user_id": "1234567890",
   "created_at": 1714764021,
   "updated_at": 1773923144,
-  "share_url": "https://groupme.com/join_group/GROUP_ID/SHARE_TOKEN",
+  "share_url": "https://groupme.com/join_group/1234567890/SHARE_TOKEN",
   "members": [
     {
-      "id": "MEMBERSHIP_ID",
-      "user_id": "USER_ID",
-      "nickname": "USERNAME",
+      "id": "123456789",
+      "user_id": "123456789",
+      "nickname": "John",
       "muted": false,
-      "image_url": "https://example.com/avatar.jpeg"
+      "image_url": "https://i.groupme.com/123456789"
     }
   ],
   "messages": {
     "count": 100,
-    "last_message_id": "MESSAGE_ID",
+    "last_message_id": "1234567890",
     "last_message_created_at": 1773923144
   }
 }

--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -36,7 +36,7 @@ List the authenticated user's active groups.
 
 The response is paginated, with a default of 10 groups per page.
 
-Please consider using of omit=memberships parameter. Not including member lists might significantly improve user experience of your app for users who are participating in huge groups.
+Please consider using the `omit=memberships` parameter. Omitting member lists can significantly improve performance for users who participate in very large groups.
 
 ```json linenums="1" title="HTTP Request"
 GET /groups
@@ -154,7 +154,7 @@ Status: 200 OK
           {
             "type": "image",
             "url": "https://i.groupme.com/123456789"
-          },,
+          },
           {
             "type": "location",
             "lat": "40.738206",
@@ -226,6 +226,9 @@ Load a specific group. Returns full detail for a single group.
 GET /groups/:id
 ```
 
+!!! note
+  The route uses /groups/{id}. Placeholder naming in documentation may vary (e.g., :group_id vs :id), but both refer to the same path parameter.
+
 **Parameters**
 
 * *id* (required)
@@ -234,7 +237,7 @@ GET /groups/:id
 
 **Response Schema**
 
-The detail view contains the complete group schema. Fields marked as **(detail only)** are either not present or less detailed in the [Index](#index) (list) endpoint:
+The detail endpoint provides additional member-level and message metadata compared to the list endpoint, but omits the messages.preview field present in list responses.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -248,7 +251,7 @@ The detail view contains the complete group schema. Fields marked as **(detail o
 | `updated_at` | integer | Unix timestamp of last update |
 | `share_url` | string \| null | Join URL for shared groups |
 | `members` | array | **(detail only)** List of member objects with full details. Each member includes: `id`, `user_id`, `nickname`, `muted`, `image_url` |
-| `messages` | object | **(detail only)** Message metadata including: `count`, `last_message_id`, `last_message_created_at` |
+| `messages` | object | **(detail only)** Message metadata including: `count`, `last_message_id`, `last_message_created_at`, `last_message_updated_at` |
 
 **List vs Detail Differences**
 
@@ -259,7 +262,7 @@ The detail view contains the complete group schema. Fields marked as **(detail o
 | `members` field | May be omitted via `omit=memberships`; when present, member objects exclude `id` | Always present; member objects include `id` field |
 | `messages.preview` | Present | **Not present** in detail view |
 | Complete member data | Limited | Full (includes membership `id`) |
-| Message metadata | Basic + preview | Full stats only (no preview) |
+| Message metadata | Basic + preview | Count and last-message timestamps only (no preview) |
 
 ```json linenums="1" title="HTTP Response"
 Status: 200 OK
@@ -285,7 +288,8 @@ Status: 200 OK
   "messages": {
     "count": 100,
     "last_message_id": "1234567890",
-    "last_message_created_at": 1773923144
+    "last_message_created_at": 1773923144,
+    "last_message_updated_at": 1773923205
   }
 }
 ```
@@ -394,12 +398,12 @@ POST /groups/:id/update
   "name": "Family",
   "share": true,
   "image_url": "https://i.groupme.com/123456789",
-  "office_mode": true
-  "theme_name": "cogs"
+  "office_mode": true,
+  "theme_name": "cogs",
   "requires_approval": true,
   "show_join_question": true,
   "join_question": {
-    "text": "You're not a bot, are you?"
+    "text": "You're not a bot, are you?",
     "type": "join_reason/questions/text"
   },
   "like_icon": {

--- a/docs/api/groups/index.md
+++ b/docs/api/groups/index.md
@@ -264,27 +264,27 @@ The detail view contains the complete group schema. Fields marked as **(detail o
 ```json linenums="1" title="HTTP Response"
 Status: 200 OK
 {
-  "id": "100675764",
-  "name": "ISBA Prophets",
-  "type": "closed",
-  "description": "",
-  "image_url": "https://i.groupme.com/500x500.jpeg.3e6a51af2d104dba882cf36014fca0bb",
-  "creator_user_id": "125343076",
+  "id": "GROUP_ID",
+  "name": "GROUP_NAME",
+  "type": "private",
+  "description": "GROUP_DESCRIPTION",
+  "image_url": "https://example.com/avatar.jpeg",
+  "creator_user_id": "USER_ID",
   "created_at": 1714764021,
   "updated_at": 1773923144,
-  "share_url": "https://groupme.com/join_group/100675764/6aYuFUwY",
+  "share_url": "https://groupme.com/join_group/GROUP_ID/SHARE_TOKEN",
   "members": [
     {
-      "id": "971574566",
-      "user_id": "107044098",
-      "nickname": "Khristian Diaz NW",
+      "id": "MEMBERSHIP_ID",
+      "user_id": "USER_ID",
+      "nickname": "USERNAME",
       "muted": false,
-      "image_url": "https://i.groupme.com/1024x1024.jpeg.deca0b2163f14b4f8691b194d4c68918"
+      "image_url": "https://example.com/avatar.jpeg"
     }
   ],
   "messages": {
-    "count": 6677,
-    "last_message_id": "177392314469396469",
+    "count": 100,
+    "last_message_id": "MESSAGE_ID",
     "last_message_created_at": 1773923144
   }
 }

--- a/docs/api/groups/subgroups.md
+++ b/docs/api/groups/subgroups.md
@@ -27,6 +27,9 @@ Finally, all responses are wrapped in a response envelope of the following form:
 
 If the request succeeds, `meta.errors` will be null, and if the request fails, `response` will be null.
 
+> [!warning]
+> **Type Inconsistency:** Unlike most GroupMe endpoints which use string IDs, the subgroup endpoints return `id`, `parent_id`, and `creator_user_id` as **integers**, not strings. This is an inconsistency with the rest of the API where IDs are typically strings.
+
 ***
 
 ## Index
@@ -60,43 +63,39 @@ Status: 200 OK
   {
     "messages": {
       "count": 4,
-      "last_message_id": "1234567890987654321",
+      "last_message_id": "SUBGROUP_MESSAGE_ID",
       "last_message_created_at": 1715574721,
       "last_message_updated_at": 1715574721,
       "preview": {
-        "nickname": "Bob Doe",
+        "nickname": "USERNAME",
         "text": "Hello everyone!",
-        "image_url": "https://i.groupme.com/1024x1024.jpeg.123456789e9876543211234567e",
-        "attachments": [
-          {
-            "type": "image",
-             "url": "https://i.groupme.com/123456789"
-          },
-          {
-            "type": "image",
-            "url": "https://i.groupme.com/123456789"
-          }
-        ]
+        "image_url": "https://example.com/avatar.jpeg",
+        "attachments": []
       }
     },
     "id": 123456789,
-    "parent_id": 123123123,
+    "parent_id": GROUP_ID,
     "topic": "Test Topic 1",
     "description": "This is a testing topic",
-    "avatar_url": "https://i.groupme.com/1024x1024.jpeg.123456789a9876543211234567a",
-    "creator_user_id": 12345678,
+    "avatar_url": "https://example.com/avatar.jpeg",
+    "creator_user_id": USER_ID,
     "created_at": 1715574084,
     "updated_at": 1715574721,
     "muted_until": null,
+    "recap_enabled": null,
     "like_icon": null,
     "unread_count": null,
     "last_read_message_id": null,
-    "last_read_at": null
+    "last_read_at": null,
+    "message_edit_period": 15
   }
 ]
 ```
 
 ***
+
+> [!note]
+> The `messages.preview` object in subgroups includes `last_message_updated_at`, which is **not present** in the standard group messages object. This field represents when the last message was edited/updated.
 
 ## Show
 
@@ -121,38 +120,31 @@ Status: 200 OK
 {
   "messages": {
     "count": 18,
-    "last_message_id": "1234567890987654321",
+    "last_message_id": "SUBGROUP_MESSAGE_ID",
     "last_message_created_at": 1715574721,
     "last_message_updated_at": 1715574721,
     "preview": {
-      "nickname": "Jane Doe",
+      "nickname": "USERNAME",
       "text": "Hey everyone!",
-      "image_url": "https://i.groupme.com/1024x1024.jpeg.eabcdefg1234567654321eabcdefg",
-      "attachments": [
-        {
-          "type": "image",
-          "url": "https://i.groupme.com/123456789"
-        },
-        {
-          "type": "image",
-          "url": "https://i.groupme.com/123456789"
-        }
-      ]
+      "image_url": "https://example.com/avatar.jpeg",
+      "attachments": []
     }
   },
   "id": 123456789,
-  "parent_id": 987654321,
+  "parent_id": GROUP_ID,
   "topic": "Test Topic",
   "description": "This is a testing topic",
-  "avatar_url": "https://i.groupme.com/1024x1024.jpeg.iabcdefg1234567654321iabcdefg",
-  "creator_user_id": 123123123,
+  "avatar_url": "https://example.com/avatar.jpeg",
+  "creator_user_id": USER_ID,
   "created_at": 1715574084,
   "updated_at": 1715574721,
   "muted_until": null,
+  "recap_enabled": null,
   "like_icon": null,
   "unread_count": null,
   "last_read_message_id": null,
-  "last_read_at": null
+  "last_read_at": null,
+  "message_edit_period": 15
 }
 ```
 
@@ -165,7 +157,7 @@ Create a topic. You must be an admin in the group to make this call.
 ```json linenums="1" title="HTTP Request"
 POST /groups/:group_id/subgroups
 {
-  "avatar_url": "https://i.groupme.com/1024x1024.jpeg.679caf2a3dc04bd884137065e567047f",
+  "avatar_url": "https://example.com/avatar.jpeg",
   "description": "this is a description",
   "group_type": "announcement",
   "topic": "test topic"
@@ -201,10 +193,10 @@ Status: 201 Accepted
   "topic": "test topic",
   "type": "announcement",
   "description": "this is a description",
-  "avatar_url": "https://i.groupme.com/1024x1024.jpeg.679caf2a3dc04bd884137065e567047f",
+  "avatar_url": "https://example.com/avatar.jpeg",
   "created_at": 1748457450,
   "updated_at": 1748457450,
-  "parent_id": 107876923,
+  "parent_id": GROUP_ID,
   "like_icon": null
 }
 ```
@@ -218,7 +210,7 @@ Update a topic's details
 ```json linenums="1" title="HTTP Request"
 PUT /groups/:group_id/subgroups/:subgroup_id
 {
-  "avatar_url": "https://i.groupme.com/1024x1024.jpeg.679caf2a3dc04bd884137065e567047f",
+  "avatar_url": "https://example.com/avatar.jpeg",
   "description": "this is a new description",
   "group_type": "private",
   "topic": "new name",
@@ -266,10 +258,10 @@ PUT /groups/:group_id/subgroups/:subgroup_id
   "topic": "new name",
   "type": "private",
   "description": "this is a new description",
-  "avatar_url": "https://i.groupme.com/1024x1024.jpeg.742b941f7eea46998438cee6838268ec",
+  "avatar_url": "https://example.com/avatar.jpeg",
   "created_at": 1748457450,
   "updated_at": 1748457988,
-  "parent_id": 107876923,
+  "parent_id": GROUP_ID,
   "like_icon": {
     "pack_id": 1,
     "pack_index": 49,
@@ -330,12 +322,12 @@ Status: 200 OK
 {
   "membership": {
     "id": "1080225494",
-    "user_id": "93645911",
+    "user_id": "USER_ID",
     "country_code": "1",
-    "phone_number": "3192414622",
-    "email": "stanger.isaac@gmail.com",
-    "avatar_url": "https://i.groupme.com/200x200.jpeg.94e0ac5891aa4e6f8ad4bbf961defe4d",
-    "nickname": "Isaac",
+    "phone_number": "PHONE_NUMBER",
+    "email": "user@example.com",
+    "avatar_url": "https://example.com/avatar.jpeg",
+    "nickname": "USERNAME",
     "creator": true,
     "muted": false,
     "snoozed": false,
@@ -343,7 +335,7 @@ Status: 200 OK
     "pending": false,
     "muted_until": null,
     "muted_children": {
-      "107933452": 253402300800
+      "SUBGROUP_ID": 253402300800
     }
   }
 }

--- a/docs/api/groups/subgroups.md
+++ b/docs/api/groups/subgroups.md
@@ -27,8 +27,8 @@ Finally, all responses are wrapped in a response envelope of the following form:
 
 If the request succeeds, `meta.errors` will be null, and if the request fails, `response` will be null.
 
-> [!warning]
-> **Type Inconsistency:** Unlike most GroupMe endpoints which use string IDs, the subgroup endpoints return `id`, `parent_id`, and `creator_user_id` as **integers**, not strings. This is an inconsistency with the rest of the API where IDs are typically strings.
+!!! warning
+    **Type Inconsistency:** Unlike most GroupMe endpoints which use string IDs, the subgroup endpoints return `id`, `parent_id`, and `creator_user_id` as **integers**, not strings. This is an inconsistency with the rest of the API where IDs are typically strings.
 
 ***
 
@@ -63,24 +63,33 @@ Status: 200 OK
   {
     "messages": {
       "count": 4,
-      "last_message_id": "SUBGROUP_MESSAGE_ID",
-      "last_message_created_at": 1715574721,
-      "last_message_updated_at": 1715574721,
+      "last_message_id": "1234567890",
+      "last_message_created_at": 1302623328,
+      "last_message_updated_at": 1302623328,
       "preview": {
-        "nickname": "USERNAME",
+        "nickname": "John",
         "text": "Hello everyone!",
-        "image_url": "https://example.com/avatar.jpeg",
-        "attachments": []
+        "image_url": "https://i.groupme.com/123456789",
+        "attachments": [
+          {
+            "type": "image",
+             "url": "https://i.groupme.com/123456789"
+          },
+          {
+            "type": "image",
+            "url": "https://i.groupme.com/123456789"
+          }
+        ]
       }
     },
     "id": 123456789,
-    "parent_id": GROUP_ID,
+    "parent_id": 123456789,
     "topic": "Test Topic 1",
     "description": "This is a testing topic",
-    "avatar_url": "https://example.com/avatar.jpeg",
-    "creator_user_id": USER_ID,
-    "created_at": 1715574084,
-    "updated_at": 1715574721,
+    "avatar_url": "https://i.groupme.com/123456789",
+    "creator_user_id": 12345678,
+    "created_at": 1302623328,
+    "updated_at": 1302623328,
     "muted_until": null,
     "recap_enabled": null,
     "like_icon": null,
@@ -94,8 +103,8 @@ Status: 200 OK
 
 ***
 
-> [!note]
-> The `messages.preview` object in subgroups includes `last_message_updated_at`, which is **not present** in the standard group messages object. This field represents when the last message was edited/updated.
+!!! note
+    The `messages.preview` object in subgroups includes `last_message_updated_at`, which is **not present** in the standard group messages object. This field represents when the last message was edited/updated.
 
 ## Show
 
@@ -120,24 +129,33 @@ Status: 200 OK
 {
   "messages": {
     "count": 18,
-    "last_message_id": "SUBGROUP_MESSAGE_ID",
+    "last_message_id": "1234567890",
     "last_message_created_at": 1715574721,
     "last_message_updated_at": 1715574721,
     "preview": {
-      "nickname": "USERNAME",
+      "nickname": "Jane",
       "text": "Hey everyone!",
-      "image_url": "https://example.com/avatar.jpeg",
-      "attachments": []
+      "image_url": "https://i.groupme.com/123456789",
+      "attachments": [
+        {
+          "type": "image",
+          "url": "https://i.groupme.com/123456789"
+        },
+        {
+          "type": "image",
+          "url": "https://i.groupme.com/123456789"
+        }
+      ]
     }
   },
   "id": 123456789,
-  "parent_id": GROUP_ID,
+  "parent_id": 123456789,
   "topic": "Test Topic",
   "description": "This is a testing topic",
-  "avatar_url": "https://example.com/avatar.jpeg",
-  "creator_user_id": USER_ID,
-  "created_at": 1715574084,
-  "updated_at": 1715574721,
+  "avatar_url": "https://i.groupme.com/123456789",
+  "creator_user_id": 12345678,
+  "created_at": 1302623328,
+  "updated_at": 1302623328,
   "muted_until": null,
   "recap_enabled": null,
   "like_icon": null,
@@ -157,7 +175,7 @@ Create a topic. You must be an admin in the group to make this call.
 ```json linenums="1" title="HTTP Request"
 POST /groups/:group_id/subgroups
 {
-  "avatar_url": "https://example.com/avatar.jpeg",
+  "avatar_url": "https://i.groupme.com/123456789",
   "description": "this is a description",
   "group_type": "announcement",
   "topic": "test topic"
@@ -189,14 +207,14 @@ POST /groups/:group_id/subgroups
 ```json linenums="1" title="HTTP Response"
 Status: 201 Accepted
 {
-  "id": 107877040,
+  "id": 123456789,
   "topic": "test topic",
   "type": "announcement",
   "description": "this is a description",
-  "avatar_url": "https://example.com/avatar.jpeg",
-  "created_at": 1748457450,
-  "updated_at": 1748457450,
-  "parent_id": GROUP_ID,
+  "avatar_url": "https://i.groupme.com/123456789",
+  "created_at": 1302623328,
+  "updated_at": 1302623328,
+  "parent_id": 123456789,
   "like_icon": null
 }
 ```
@@ -210,7 +228,7 @@ Update a topic's details
 ```json linenums="1" title="HTTP Request"
 PUT /groups/:group_id/subgroups/:subgroup_id
 {
-  "avatar_url": "https://example.com/avatar.jpeg",
+  "avatar_url": "https://i.groupme.com/123456789",
   "description": "this is a new description",
   "group_type": "private",
   "topic": "new name",
@@ -254,14 +272,14 @@ PUT /groups/:group_id/subgroups/:subgroup_id
 
 ```json linenums="1" title="HTTP Response"
 {
-  "id": 107877040,
+  "id": 123456789,
   "topic": "new name",
   "type": "private",
   "description": "this is a new description",
-  "avatar_url": "https://example.com/avatar.jpeg",
-  "created_at": 1748457450,
-  "updated_at": 1748457988,
-  "parent_id": GROUP_ID,
+  "avatar_url": "https://i.groupme.com/123456789",
+  "created_at": 1302623328,
+  "updated_at": 1302623328,
+  "parent_id": 123456789,
   "like_icon": {
     "pack_id": 1,
     "pack_index": 49,
@@ -321,13 +339,13 @@ POST /groups/:group_id/subgroups/:subgroup_id/unmute
 Status: 200 OK
 {
   "membership": {
-    "id": "1080225494",
-    "user_id": "USER_ID",
+    "id": "1234567890",
+    "user_id": "123456789",
     "country_code": "1",
-    "phone_number": "PHONE_NUMBER",
+    "phone_number": "1234567890",
     "email": "user@example.com",
-    "avatar_url": "https://example.com/avatar.jpeg",
-    "nickname": "USERNAME",
+    "avatar_url": "https://i.groupme.com/123456789",
+    "nickname": "John",
     "creator": true,
     "muted": false,
     "snoozed": false,
@@ -335,7 +353,7 @@ Status: 200 OK
     "pending": false,
     "muted_until": null,
     "muted_children": {
-      "SUBGROUP_ID": 253402300800
+      "123456789": 253402300800
     }
   }
 }

--- a/docs/api/groups/subgroups.md
+++ b/docs/api/groups/subgroups.md
@@ -30,6 +30,17 @@ If the request succeeds, `meta.errors` will be null, and if the request fails, `
 !!! warning
     **Type Inconsistency:** Unlike most GroupMe endpoints which use string IDs, the subgroup endpoints return `id`, `parent_id`, and `creator_user_id` as **integers**, not strings. This is an inconsistency with the rest of the API where IDs are typically strings.
 
+!!! note
+  Subgroup message retrieval uses the flat group-style endpoint:
+
+  GET /groups/{subgroup_id}/messages
+
+  even though subgroup metadata is accessed via:
+
+  GET /groups/{group_id}/subgroups/{subgroup_id}
+
+  This distinction was verified via live API testing.
+
 ***
 
 ## Index
@@ -73,10 +84,6 @@ Status: 200 OK
         "attachments": [
           {
             "type": "image",
-             "url": "https://i.groupme.com/123456789"
-          },
-          {
-            "type": "image",
             "url": "https://i.groupme.com/123456789"
           }
         ]
@@ -104,7 +111,7 @@ Status: 200 OK
 ***
 
 !!! note
-    The `messages.preview` object in subgroups includes `last_message_updated_at`, which is **not present** in the standard group messages object. This field represents when the last message was edited/updated.
+  The subgroup `messages` object includes `last_message_updated_at`, which is not present in standard group message metadata. This field represents when the last message was edited or otherwise updated.
 
 ## Show
 
@@ -137,10 +144,6 @@ Status: 200 OK
       "text": "Hey everyone!",
       "image_url": "https://i.groupme.com/123456789",
       "attachments": [
-        {
-          "type": "image",
-          "url": "https://i.groupme.com/123456789"
-        },
         {
           "type": "image",
           "url": "https://i.groupme.com/123456789"
@@ -212,9 +215,11 @@ Status: 201 Accepted
   "type": "announcement",
   "description": "this is a description",
   "avatar_url": "https://i.groupme.com/123456789",
+  "creator_user_id": 12345678,
   "created_at": 1302623328,
   "updated_at": 1302623328,
   "parent_id": 123456789,
+  "message_edit_period": 15,
   "like_icon": null
 }
 ```
@@ -277,9 +282,11 @@ PUT /groups/:group_id/subgroups/:subgroup_id
   "type": "private",
   "description": "this is a new description",
   "avatar_url": "https://i.groupme.com/123456789",
+  "creator_user_id": 12345678,
   "created_at": 1302623328,
   "updated_at": 1302623328,
   "parent_id": 123456789,
+  "message_edit_period": 15,
   "like_icon": {
     "pack_id": 1,
     "pack_index": 49,


### PR DESCRIPTION
## What's changed

### `GET /groups/:id` (index.md)
- Added full response schema table documenting all fields returned by the detail endpoint
- Added **List vs Detail comparison table** clarifying which fields are exclusive to the detail view (`members`, `messages` metadata) vs the index endpoint
- Corrected the example response to remove the `messages.preview` block, which is present on the list endpoint but **not** returned by the detail endpoint
- Documented that `members[]` objects include a membership-scoped `id` field in the detail view that is absent from the list view

### Subgroups (subgroups.md)
- Added `!!! warning` noting that `id`, `parent_id`, and `creator_user_id` are returned as **integers** in subgroup responses, unlike the rest of the API which uses strings
- Added previously undocumented field `message_edit_period` (value: `15`) to both Index and Show response examples
- Added `last_message_updated_at` to the `messages` object in subgroup responses — this field is present on subgroups but **absent** from the standard group messages object
- Added `!!! note` clarifying the above distinction

## How this was verified
All schema changes were verified via live API capture using a working GroupMe MCP server against real group data.